### PR TITLE
fix for linalg.det_inv

### DIFF
--- a/ulinalg.py
+++ b/ulinalg.py
@@ -58,7 +58,7 @@ def det_inv(x):
     else:
         # divide each row element by [0] to give a one in the first position
         # (may have to find a row to switch with if first element is 0)
-        x = x.copy()
+        x = x.copy(dtype=float)
         inverse = eye(len(x), dtype=float)
         sign = 1
         factors = []

--- a/umatrix.py
+++ b/umatrix.py
@@ -352,10 +352,10 @@ class matrix(object):
         ''' scaler ** matrix elementwise power '''
         return self.__OP__(a, '**')
 
-    def copy(self):
+    def copy(self, dtype=None):
         """ Return a copy of matrix, not just a view """
         return matrix([i for i in self.data],
-                      cstride=self.cstride, rstride=self.rstride)
+                      cstride=self.cstride, rstride=self.rstride, dtype=dtype)
 
     def size(self, axis=0):
         """ 0 entries


### PR DESCRIPTION
Currently, `ulinalg.det_inv()` does not correctly calculate the determinant and matrix inverse for matricies of `dtype=int`. 
```
>>> a = umatrix.matrix([3, 1, 1, 2], cstride=1, rstride=2)
>>> det, a_inv = ulinalg.det_inv(a) 
>>> print(det)
6
>>> print(a_inv)
mat([[0.3333333333333333 , 0.0                ],
     [-0.1666666666666667, 0.5                ]])
```

The determinant of `a` should be 5. 
> <a href="https://www.codecogs.com/eqnedit.php?latex=det\begin{pmatrix}\begin{bmatrix}&space;a&space;&&space;b&space;\\&space;c&space;&&space;d&space;\end{bmatrix}\end{pmatrix}&space;=&space;ad-bc&space;\;\;&space;\Rightarrow&space;\;\;&space;det\begin{pmatrix}\begin{bmatrix}&space;3&space;&&space;1&space;\\&space;1&space;&&space;2&space;\end{bmatrix}\end{pmatrix}&space;=&space;3*2-1*1&space;=&space;5" target="_blank"><img src="https://latex.codecogs.com/gif.latex?det\begin{pmatrix}\begin{bmatrix}&space;a&space;&&space;b&space;\\&space;c&space;&&space;d&space;\end{bmatrix}\end{pmatrix}&space;=&space;ad-bc&space;\;\;&space;\Rightarrow&space;\;\;&space;det\begin{pmatrix}\begin{bmatrix}&space;3&space;&&space;1&space;\\&space;1&space;&&space;2&space;\end{bmatrix}\end{pmatrix}&space;=&space;3*2-1*1&space;=&space;5" title="det\begin{pmatrix}\begin{bmatrix} a & b \\ c & d \end{bmatrix}\end{pmatrix} = ad-bc \;\; \Rightarrow \;\; det\begin{pmatrix}\begin{bmatrix} 3 & 1 \\ 1 & 2 \end{bmatrix}\end{pmatrix} = 3*2-1*1 = 5" /></a>


Specifying the matrix be of type `float` fixes the calculation. 
```
>>> a = umatrix.matrix([3, 1, 1, 2], cstride=1, rstride=2, dtype=float)
>>> det, a_inv = ulinalg.det_inv(a)
>>> print(det)
5.0
>>> print(a_inv)
mat([[0.4 , -0.2],
     [-0.2, 0.6 ]])
```

To fix this, I added a `dtype=None` option to the `copy` method in the `matrix` class. I also changed `ulinalg.det_inv` to use `dtype=float` for the copy of the input matrix. With those changes, the answer is the same for matricies of `dtype=int` and `dtype=float`.
```
>>> a = umatrix.matrix([3, 1, 1, 2], cstride=1, rstride=2)
>>> det, a_inv = ulinalg.det_inv(a)
>>> print(det)
5.0
>>> print(a_inv)
mat([[0.4 , -0.2],
     [-0.2, 0.6 ]])
```

This error seems to stem from the in-place slice assignments to the copy of `x` (the input) in `ulinalg.det_inv`. The `matrix` class implicitly casts those values to match the `x`'s dtype. 

_Example:_ 
```
>>> a = umatrix.matrix([3, 1, 1, 2], cstride=1, rstride=2, dtype=int)
>>> a
mat([[3, 1],
     [1, 2]])
>>> a[0, 0] = 1.9
>>> a
mat([[1, 1],
     [1, 2]])
```

This change shouldn't break anything, but if that `matrix` behavior affects other functions, this change won't fix those. 